### PR TITLE
Add Linux compatibility shims for libndmp

### DIFF
--- a/trunk/usr/src/lib/libndmp/Makefile.com
+++ b/trunk/usr/src/lib/libndmp/Makefile.com
@@ -38,26 +38,36 @@
 #
 LIBRARY= libndmp.a
 VERS= .1
-OBJECTS= libndmp.o libndmp_error.o libndmp_door_data.o libndmp_prop.o libndmp_base64.o
+COMMON_OBJECTS= libndmp.o libndmp_error.o libndmp_door_data.o libndmp_prop.o \
+    libndmp_base64.o
+COMPAT_OBJECTS= door_compat.o libscf_compat.o
+OBJECTS= $(COMMON_OBJECTS) $(COMPAT_OBJECTS)
 
 include ../../Makefile.lib
 
 SRCDIR =	../common
+COMPATDIR =	../compat
+INCS += -I$(COMPATDIR)
 INCS += -I$(SRCDIR)
 INCS += -I$(SRC)/cmd/ndmpd/include
 
 C99MODE=	-xc99=%all
 C99LMODE=	-Xc99=%all
 LIBS=	$(DYNLIB) $(LINTLIB)
-LDLIBS +=	-lc -lscf
+LDLIBS +=	-lc
 CPPFLAGS +=	$(INCS) -D_REENTRANT
 
-SRCS=	$(OBJECTS:%.o=$(SRCDIR)/%.c)
+SRCS=	$(COMMON_OBJECTS:%.o=$(SRCDIR)/%.c) \
+	$(COMPAT_OBJECTS:%.o=$(COMPATDIR)/%.c)
 $(LINTLIB) := SRCS=	$(SRCDIR)/$(LINTSRC)
 
 .KEEP_STATE:
 
 all: $(LIBS)
+
+$(COMPAT_OBJECTS): %.o: $(COMPATDIR)/%.c
+	$(COMPILE.c) -o $@ $<
+	$(POST_PROCESS_O)
 
 lint: lintcheck
 

--- a/trunk/usr/src/lib/libndmp/compat/door.h
+++ b/trunk/usr/src/lib/libndmp/compat/door.h
@@ -1,0 +1,28 @@
+#ifndef _LIBNDMP_COMPAT_DOOR_H
+#define _LIBNDMP_COMPAT_DOOR_H
+
+#ifdef __sun
+#include_next <door.h>
+#else
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct door_desc {
+        int d_descriptor;
+} door_desc_t;
+
+typedef struct door_arg {
+        char *data_ptr;
+        size_t data_size;
+        char *rbuf;
+        size_t rsize;
+        door_desc_t *desc_ptr;
+        unsigned int desc_num;
+} door_arg_t;
+
+int door_call(int, door_arg_t *);
+
+#endif /* __sun */
+
+#endif /* _LIBNDMP_COMPAT_DOOR_H */

--- a/trunk/usr/src/lib/libndmp/compat/door_compat.c
+++ b/trunk/usr/src/lib/libndmp/compat/door_compat.c
@@ -1,0 +1,15 @@
+#include "door.h"
+
+#ifndef __sun
+#include <errno.h>
+
+int
+door_call(int fd, door_arg_t *arg)
+{
+        (void)fd;
+        (void)arg;
+        errno = ENOTSUP;
+        return (-1);
+}
+
+#endif /* __sun */

--- a/trunk/usr/src/lib/libndmp/compat/libscf.h
+++ b/trunk/usr/src/lib/libndmp/compat/libscf.h
@@ -1,0 +1,98 @@
+#ifndef _LIBNDMP_COMPAT_LIBSCF_H
+#define _LIBNDMP_COMPAT_LIBSCF_H
+
+#ifdef __sun
+#include_next <libscf.h>
+#else
+#include <stdint.h>
+#include <sys/types.h>
+
+#define SCF_VERSION                     1
+#define SCF_SUCCESS                     0
+#define SCF_FAILED                      (-1)
+
+#define SCF_GROUP_FRAMEWORK             "framework"
+
+typedef enum {
+        SCF_TYPE_INVALID = 0,
+        SCF_TYPE_ASTRING,
+        SCF_TYPE_INTEGER,
+        SCF_TYPE_BOOLEAN
+} scf_type_t;
+
+typedef struct scf_handle scf_handle_t;
+typedef struct scf_scope scf_scope_t;
+typedef struct scf_service scf_service_t;
+typedef struct scf_propertygroup scf_propertygroup_t;
+typedef struct scf_transaction scf_transaction_t;
+typedef struct scf_transaction_entry scf_transaction_entry_t;
+typedef struct scf_property scf_property_t;
+typedef struct scf_value scf_value_t;
+
+#define SCF_ERROR_NONE                  0
+#define SCF_ERROR_NOT_SUPPORTED         1001
+#define SCF_ERROR_PERMISSION_DENIED     1002
+#define SCF_ERROR_INTERNAL              1003
+
+scf_handle_t *scf_handle_create(uint32_t);
+void scf_handle_destroy(scf_handle_t *);
+int scf_handle_bind(scf_handle_t *);
+int scf_handle_unbind(scf_handle_t *);
+
+scf_scope_t *scf_scope_create(scf_handle_t *);
+void scf_scope_destroy(scf_scope_t *);
+int scf_handle_get_local_scope(scf_handle_t *, scf_scope_t *);
+int scf_scope_get_service(scf_scope_t *, const char *, scf_service_t *);
+
+scf_service_t *scf_service_create(scf_handle_t *);
+void scf_service_destroy(scf_service_t *);
+int scf_service_get_pg(scf_service_t *, const char *, scf_propertygroup_t *);
+int scf_service_add_pg(scf_service_t *, const char *, const char *, uint32_t,
+    scf_propertygroup_t *);
+
+scf_propertygroup_t *scf_pg_create(scf_handle_t *);
+void scf_pg_destroy(scf_propertygroup_t *);
+int scf_pg_get_property(scf_propertygroup_t *, const char *, scf_property_t *);
+
+scf_property_t *scf_property_create(scf_handle_t *);
+void scf_property_destroy(scf_property_t *);
+int scf_property_get_value(scf_property_t *, scf_value_t *);
+
+scf_transaction_t *scf_transaction_create(scf_handle_t *);
+void scf_transaction_destroy(scf_transaction_t *);
+void scf_transaction_destroy_children(scf_transaction_t *);
+int scf_transaction_start(scf_transaction_t *, scf_propertygroup_t *);
+int scf_transaction_commit(scf_transaction_t *);
+
+scf_transaction_entry_t *scf_entry_create(scf_handle_t *);
+void scf_entry_destroy(scf_transaction_entry_t *);
+int scf_entry_add_value(scf_transaction_entry_t *, scf_value_t *);
+
+int scf_transaction_property_delete(scf_transaction_t *,
+    scf_transaction_entry_t *, const char *);
+int scf_transaction_property_change(scf_transaction_t *,
+    scf_transaction_entry_t *, const char *, scf_type_t);
+int scf_transaction_property_new(scf_transaction_t *,
+    scf_transaction_entry_t *, const char *, scf_type_t);
+
+scf_value_t *scf_value_create(scf_handle_t *);
+void scf_value_destroy(scf_value_t *);
+scf_type_t scf_value_type(const scf_value_t *);
+
+int scf_value_set_astring(scf_value_t *, const char *);
+void scf_value_set_integer(scf_value_t *, int64_t);
+void scf_value_set_boolean(scf_value_t *, uint8_t);
+
+ssize_t scf_value_get_astring(const scf_value_t *, char *, size_t);
+int scf_value_get_integer(const scf_value_t *, int64_t *);
+int scf_value_get_boolean(const scf_value_t *, uint8_t *);
+
+int scf_error(void);
+const char *scf_strerror(int);
+
+char *smf_get_state(const char *);
+int smf_refresh_instance(const char *);
+
+#endif /* __sun */
+
+#endif /* _LIBNDMP_COMPAT_LIBSCF_H */

--- a/trunk/usr/src/lib/libndmp/compat/libscf_compat.c
+++ b/trunk/usr/src/lib/libndmp/compat/libscf_compat.c
@@ -1,0 +1,434 @@
+#include "libscf.h"
+
+#ifndef __sun
+#include <errno.h>
+#include <stdlib.h>
+
+struct scf_handle {
+        uint32_t version;
+};
+
+struct scf_scope {
+        int unused;
+};
+
+struct scf_service {
+        int unused;
+};
+
+struct scf_propertygroup {
+        int unused;
+};
+
+struct scf_transaction {
+        int unused;
+};
+
+struct scf_transaction_entry {
+        int unused;
+};
+
+struct scf_property {
+        int unused;
+};
+
+struct scf_value {
+        scf_type_t type;
+};
+
+static int compat_scf_error = SCF_ERROR_NOT_SUPPORTED;
+
+static void
+compat_set_error(int err)
+{
+        compat_scf_error = err;
+}
+
+scf_handle_t *
+scf_handle_create(uint32_t version)
+{
+        scf_handle_t *handle;
+
+        if (version != SCF_VERSION) {
+                errno = ENOTSUP;
+                compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+                return (NULL);
+        }
+
+        handle = calloc(1, sizeof (*handle));
+        if (handle == NULL) {
+                compat_set_error(SCF_ERROR_INTERNAL);
+                return (NULL);
+        }
+
+        handle->version = version;
+        compat_set_error(SCF_ERROR_NONE);
+        return (handle);
+}
+
+void
+scf_handle_destroy(scf_handle_t *handle)
+{
+        free(handle);
+}
+
+int
+scf_handle_bind(scf_handle_t *handle)
+{
+        (void)handle;
+        errno = ENOTSUP;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (-1);
+}
+
+int
+scf_handle_unbind(scf_handle_t *handle)
+{
+        (void)handle;
+        compat_set_error(SCF_ERROR_NONE);
+        return (0);
+}
+
+scf_scope_t *
+scf_scope_create(scf_handle_t *handle)
+{
+        (void)handle;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (NULL);
+}
+
+void
+scf_scope_destroy(scf_scope_t *scope)
+{
+        free(scope);
+}
+
+int
+scf_handle_get_local_scope(scf_handle_t *handle, scf_scope_t *scope)
+{
+        (void)handle;
+        (void)scope;
+        errno = ENOTSUP;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (-1);
+}
+
+scf_service_t *
+scf_service_create(scf_handle_t *handle)
+{
+        (void)handle;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (NULL);
+}
+
+void
+scf_service_destroy(scf_service_t *svc)
+{
+        free(svc);
+}
+
+int
+scf_scope_get_service(scf_scope_t *scope, const char *name, scf_service_t *svc)
+{
+        (void)scope;
+        (void)name;
+        (void)svc;
+        errno = ENOTSUP;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (-1);
+}
+
+scf_propertygroup_t *
+scf_pg_create(scf_handle_t *handle)
+{
+        (void)handle;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (NULL);
+}
+
+void
+scf_pg_destroy(scf_propertygroup_t *pg)
+{
+        free(pg);
+}
+
+int
+scf_service_get_pg(scf_service_t *svc, const char *name, scf_propertygroup_t *pg)
+{
+        (void)svc;
+        (void)name;
+        (void)pg;
+        errno = ENOTSUP;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (-1);
+}
+
+int
+scf_service_add_pg(scf_service_t *svc, const char *pgname, const char *pgtype,
+    uint32_t flags, scf_propertygroup_t *pg)
+{
+        (void)svc;
+        (void)pgname;
+        (void)pgtype;
+        (void)flags;
+        (void)pg;
+        errno = ENOTSUP;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (-1);
+}
+
+scf_property_t *
+scf_property_create(scf_handle_t *handle)
+{
+        (void)handle;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (NULL);
+}
+
+void
+scf_property_destroy(scf_property_t *prop)
+{
+        free(prop);
+}
+
+int
+scf_pg_get_property(scf_propertygroup_t *pg, const char *name,
+    scf_property_t *prop)
+{
+        (void)pg;
+        (void)name;
+        (void)prop;
+        errno = ENOTSUP;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (-1);
+}
+
+int
+scf_property_get_value(scf_property_t *prop, scf_value_t *value)
+{
+        (void)prop;
+        (void)value;
+        errno = ENOTSUP;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (-1);
+}
+
+scf_transaction_t *
+scf_transaction_create(scf_handle_t *handle)
+{
+        (void)handle;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (NULL);
+}
+
+void
+scf_transaction_destroy(scf_transaction_t *tx)
+{
+        free(tx);
+}
+
+void
+scf_transaction_destroy_children(scf_transaction_t *tx)
+{
+        (void)tx;
+}
+
+int
+scf_transaction_start(scf_transaction_t *tx, scf_propertygroup_t *pg)
+{
+        (void)tx;
+        (void)pg;
+        errno = ENOTSUP;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (-1);
+}
+
+int
+scf_transaction_commit(scf_transaction_t *tx)
+{
+        (void)tx;
+        errno = ENOTSUP;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (-1);
+}
+
+scf_transaction_entry_t *
+scf_entry_create(scf_handle_t *handle)
+{
+        (void)handle;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (NULL);
+}
+
+void
+scf_entry_destroy(scf_transaction_entry_t *entry)
+{
+        free(entry);
+}
+
+int
+scf_entry_add_value(scf_transaction_entry_t *entry, scf_value_t *value)
+{
+        (void)entry;
+        (void)value;
+        errno = ENOTSUP;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (-1);
+}
+
+int
+scf_transaction_property_delete(scf_transaction_t *tx,
+    scf_transaction_entry_t *entry, const char *name)
+{
+        (void)tx;
+        (void)entry;
+        (void)name;
+        errno = ENOTSUP;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (-1);
+}
+
+int
+scf_transaction_property_change(scf_transaction_t *tx,
+    scf_transaction_entry_t *entry, const char *name, scf_type_t type)
+{
+        (void)tx;
+        (void)entry;
+        (void)name;
+        (void)type;
+        errno = ENOTSUP;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (-1);
+}
+
+int
+scf_transaction_property_new(scf_transaction_t *tx,
+    scf_transaction_entry_t *entry, const char *name, scf_type_t type)
+{
+        (void)tx;
+        (void)entry;
+        (void)name;
+        (void)type;
+        errno = ENOTSUP;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (-1);
+}
+
+scf_value_t *
+scf_value_create(scf_handle_t *handle)
+{
+        (void)handle;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (NULL);
+}
+
+void
+scf_value_destroy(scf_value_t *value)
+{
+        free(value);
+}
+
+scf_type_t
+scf_value_type(const scf_value_t *value)
+{
+        if (value == NULL)
+                return (SCF_TYPE_INVALID);
+        return (value->type);
+}
+
+int
+scf_value_set_astring(scf_value_t *value, const char *str)
+{
+        (void)value;
+        (void)str;
+        errno = ENOTSUP;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (SCF_FAILED);
+}
+
+void
+scf_value_set_integer(scf_value_t *value, int64_t val)
+{
+        (void)value;
+        (void)val;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+}
+
+void
+scf_value_set_boolean(scf_value_t *value, uint8_t val)
+{
+        (void)value;
+        (void)val;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+}
+
+ssize_t
+scf_value_get_astring(const scf_value_t *value, char *buf, size_t bufsz)
+{
+        (void)value;
+        (void)buf;
+        (void)bufsz;
+        errno = ENOTSUP;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (-1);
+}
+
+int
+scf_value_get_integer(const scf_value_t *value, int64_t *out)
+{
+        (void)value;
+        (void)out;
+        errno = ENOTSUP;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (-1);
+}
+
+int
+scf_value_get_boolean(const scf_value_t *value, uint8_t *out)
+{
+        (void)value;
+        (void)out;
+        errno = ENOTSUP;
+        compat_set_error(SCF_ERROR_NOT_SUPPORTED);
+        return (-1);
+}
+
+int
+scf_error(void)
+{
+        return (compat_scf_error);
+}
+
+const char *
+scf_strerror(int err)
+{
+        switch (err) {
+        case SCF_ERROR_NONE:
+                return ("no error");
+        case SCF_ERROR_NOT_SUPPORTED:
+                return ("operation not supported");
+        case SCF_ERROR_PERMISSION_DENIED:
+                return ("permission denied");
+        default:
+                break;
+        }
+        return ("libscf error");
+}
+
+char *
+smf_get_state(const char *fmri)
+{
+        (void)fmri;
+        errno = ENOTSUP;
+        return (NULL);
+}
+
+int
+smf_refresh_instance(const char *fmri)
+{
+        (void)fmri;
+        errno = ENOTSUP;
+        return (-1);
+}
+
+#endif /* __sun */

--- a/trunk/usr/src/lib/libndmp/compat/synch.h
+++ b/trunk/usr/src/lib/libndmp/compat/synch.h
@@ -1,0 +1,48 @@
+#ifndef _LIBNDMP_COMPAT_SYNCH_H
+#define _LIBNDMP_COMPAT_SYNCH_H
+
+#ifdef __sun
+#include_next <synch.h>
+#else
+#include <pthread.h>
+
+typedef pthread_mutex_t mutex_t;
+
+typedef pthread_mutexattr_t mutexattr_t;
+
+typedef pthread_cond_t cond_t;
+
+typedef pthread_condattr_t condattr_t;
+
+#define DEFAULTMUTEX PTHREAD_MUTEX_INITIALIZER
+#define DEFAULTCV    PTHREAD_COND_INITIALIZER
+
+static inline int
+mutex_lock(mutex_t *m)
+{
+        return (pthread_mutex_lock(m));
+}
+
+static inline int
+mutex_unlock(mutex_t *m)
+{
+        return (pthread_mutex_unlock(m));
+}
+
+static inline int
+mutex_init(mutex_t *m, int type, void *arg)
+{
+        (void)type;
+        (void)arg;
+        return (pthread_mutex_init(m, NULL));
+}
+
+static inline int
+mutex_destroy(mutex_t *m)
+{
+        return (pthread_mutex_destroy(m));
+}
+
+#endif /* __sun */
+
+#endif /* _LIBNDMP_COMPAT_SYNCH_H */

--- a/trunk/usr/src/lib/libndmp/compat/thread.h
+++ b/trunk/usr/src/lib/libndmp/compat/thread.h
@@ -1,0 +1,13 @@
+#ifndef _LIBNDMP_COMPAT_THREAD_H
+#define _LIBNDMP_COMPAT_THREAD_H
+
+#ifdef __sun
+#include_next <thread.h>
+#else
+#include <pthread.h>
+
+typedef pthread_t thread_t;
+
+#endif /* __sun */
+
+#endif /* _LIBNDMP_COMPAT_THREAD_H */


### PR DESCRIPTION
## Summary
- add compatibility shims for door IPC, SMF/libscf calls, and basic threading primitives so libndmp can build on non-Solaris platforms
- update the libndmp makefile to add the compat include directory, compile the new sources, and drop the libscf link dependency

## Testing
- make *(fails: ../../Makefile.msg.targ missing in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cba08b7c7c832e8829787dbe9c2b3e